### PR TITLE
Use the first day of the conference to calculate the timezone differe…

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import info.metadude.android.eventfahrplan.commons.temporal.SessionDateFormatter
 import nerd.tuxmobil.fahrplan.congress.schedule.TimeSegment.Companion.TIME_GRID_MINIMUM_SEGMENT_HEIGHT
 import org.threeten.bp.ZoneOffset
 
@@ -32,10 +33,12 @@ internal class TimeSegment private constructor(
     }
 
     private val roundedMoment: Moment
+    private val currDate: Moment
 
     init {
         val remainder = moment.minuteOfDay % TIME_GRID_MINIMUM_SEGMENT_HEIGHT
         roundedMoment = moment.minusMinutes(remainder.toLong())
+        currDate = moment
     }
 
     /**
@@ -44,8 +47,11 @@ internal class TimeSegment private constructor(
      *
      * See [DateFormatter.getFormattedTime24Hour].
      */
-    fun getFormattedText(sessionZoneOffset: ZoneOffset?, useDeviceTimeZone: Boolean): String =
-        DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime24Hour(roundedMoment, sessionZoneOffset)
+    fun getFormattedText(sessionZoneOffset: ZoneOffset?, useDeviceTimeZone: Boolean): String {
+        val sessionDateFormatter = SessionDateFormatter.newInstance(useDeviceTimeZone)
+        sessionDateFormatter.setTargetDate(currDate.year, currDate.month, currDate.monthDay)
+        return sessionDateFormatter.getFormattedTime24Hour(roundedMoment, sessionZoneOffset)
+    }
 
     /**
      * Returns true if the given [otherMoment] matches the internal rounded moment taken the

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -1,6 +1,7 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
 import org.threeten.bp.Instant
+import org.threeten.bp.LocalDateTime
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
@@ -11,7 +12,7 @@ import org.threeten.bp.format.FormatStyle
 /**
  * Format timestamps according to system locale and system time zone.
  */
-class DateFormatter private constructor(
+open class DateFormatter constructor(
 
     val useDeviceTimeZone: Boolean
 
@@ -116,7 +117,7 @@ class DateFormatter private constructor(
      * Returns the available zone offset - either the given [sessionZoneOffset] or the zone offset
      * of the device. The user can overrule the logic by setting [useDeviceTimeZone].
      */
-    private fun getAvailableZoneOffset(sessionZoneOffset: ZoneOffset?): ZoneOffset {
+    open fun getAvailableZoneOffset(sessionZoneOffset: ZoneOffset?): ZoneOffset {
         val deviceZoneOffset = OffsetDateTime.now().offset
         val useDeviceZoneOffset = sessionZoneOffset == null || sessionZoneOffset == deviceZoneOffset
         return if (useDeviceTimeZone || useDeviceZoneOffset) deviceZoneOffset else sessionZoneOffset!!
@@ -126,6 +127,42 @@ class DateFormatter private constructor(
 
         fun newInstance(useDeviceTimeZone: Boolean): DateFormatter {
             return DateFormatter(useDeviceTimeZone)
+        }
+    }
+}
+
+/**
+ * Format timestamps according to system locale and system time zone.
+ * Take conference date into account
+ */
+class SessionDateFormatter(useDeviceTimeZone: Boolean
+): DateFormatter(useDeviceTimeZone) {
+
+    private var day_year: Int = 2025
+    private var day_month: Int = 1
+    private var day_monthDay: Int = 1
+
+    fun setTargetDate(year1: Int, month1: Int, monthDay1: Int)  {
+        day_year = year1
+        day_month = month1
+        day_monthDay = monthDay1
+    }
+
+    override fun getAvailableZoneOffset(sessionZoneOffset: ZoneOffset?): ZoneOffset {
+        // !!! fix data start here, need to be replaced later
+        val zoneId = ZoneId.of("Europe/Vienna")  // target zone
+        // !!! fix data end here
+        val localDateTime = LocalDateTime.of(day_year, day_month, day_monthDay, 0, 0)  // target date+time
+        val zonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
+        val deviceZoneOffset = zonedDateTime.offset
+        val useDeviceZoneOffset = sessionZoneOffset == null || sessionZoneOffset == deviceZoneOffset
+        return if (useDeviceTimeZone || useDeviceZoneOffset) deviceZoneOffset else sessionZoneOffset!!
+    }
+
+    companion object {
+
+        fun newInstance(useDeviceTimeZone: Boolean): SessionDateFormatter {
+            return SessionDateFormatter(useDeviceTimeZone)
         }
     }
 }


### PR DESCRIPTION
…nce when display the session time, so to avoid the gap between CET and CEST.

Currently the timezone is fixed to 'Europe/Vienna' which is correct for Grazer LinuxTage, but not the other conferences. This should be fixed further.

# Acknowledgments
Please check the following boxes with an `x` if they apply:
* [ ] I have read the recent version of the [contribution guide](
  https://github.com/linuxtage/EventFahrplan/blob/master/CONTRIBUTING.md) before creating this pull request.
* [ ] I have checked a few other pull requests to see how they are written.
* [ ] The feature I want to propose would be useful for the majority of users, not only for me personally.
* [ ] I am aware that EventFahrplan is mostly developed by one person in their unpaid spare time.
* [ ] I can help myself to get this feature implemented or know someone who wants to do it.

# Description
<!--
- Short summary of what you are trying to accomplish.
- Link to the associated issue if applicable.
- Link to an external bug tracker if applicable.
- Which device/emulator and Android version did you test on?
-->

# Before
<!--
- Describe the behavior before the change.
- Add screenshot(s).
-->

# After
<!--
- Describe the behavior after the change.
- Add screenshot(s).
-->

<!-- Remove it this pull request does not resolve an issue -->
Resolves #
