### PR TITLE
Target Android 16 (API 36)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
     buildToolsVersion = Android.buildToolsVersion
 
     defaultConfig {
-        versionCode 1700028
-        versionName "1.8.28"
+        versionCode 1700029
+        versionName "1.8.29"
         minSdk Android.minSdkVersion
         targetSdk Android.targetSdkVersion
         base.archivesName = "Fahrplan-$versionName"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
 
     <application
         android:name="nerd.tuxmobil.fahrplan.congress.MyApp"
-        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -10,9 +10,9 @@ object Config {
 
 object Android {
     const val buildToolsVersion = "36.0.0"
-    const val compileSdkVersion = 35
+    const val compileSdkVersion = 36
     const val minSdkVersion = 21
-    const val targetSdkVersion = 35
+    const val targetSdkVersion = 36
 }
 
 object Compose {


### PR DESCRIPTION
Updates compileSdkVersion and targetSdkVersion from 35 to 36 to meet the Google Play requirement effective August 31, 2026.

Verified:
- Successful build
- Unit tests passed (testGlt22DebugUnitTest)
- Successfully installed and tested on an Android 16 emulator
- Installed package reports targetSdk=36